### PR TITLE
nlf.find never seems to complete

### DIFF
--- a/test/unit/nlf.js
+++ b/test/unit/nlf.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var nlf = require('../../lib/nlf');
+
+describe('nlf', function () {
+  describe('.find()', function () {
+    it('should work', function (done) {
+      this.timeout(50000);
+      nlf.find(process.cwd(), function (err, data) {
+        if (err) {
+          return done(err);
+        }
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
`nlf.find()` never seems to complete.  i've added a failing test proving this:

``` sh
$ make test

  ...

  nlf
    .find()
      1) should work


  16 passing (50 seconds)
  1 failing

  1) nlf .find() should work:
     Error: timeout of 50000ms exceeded
      at null.<anonymous> (/Users/stephenmathieson/work/nlf/node_modules/mocha/lib/runnable.js:139:19)
      at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)

```
