### PR TITLE
optional levenshtein edit distance 

### DIFF
--- a/lib/edit-distance-match.js
+++ b/lib/edit-distance-match.js
@@ -1,0 +1,32 @@
+'use strict';
+
+var editDistance = require('fast-levenshtein').get,
+	assert = require('assert');
+
+
+function editDistanceMatch(text, licenseNames, spdxLicenses, take) {
+	assert(licenseNames.length > 0, 'licenseNames must be non-empty');
+	assert(Object.keys(spdxLicenses).length >= licenseNames.length,
+				 'spdxLicenses must be at least as long as licenseNames');
+
+	if (!take) {
+		take = 500;
+	}
+
+	var scores = licenseNames.map(function(name) {
+		var score = editDistance(
+      text.slice(0,take), spdxLicenses[name].license.slice(0,take));
+		return {name: name, score: score};
+	});
+
+	var bestScore = scores[0];
+	scores.forEach(function(score) {
+		if (score.score < bestScore.score) {
+			bestScore = score;
+		}
+	});
+
+	return bestScore.name;
+}
+
+module.exports = editDistanceMatch;

--- a/lib/file-source.js
+++ b/lib/file-source.js
@@ -51,12 +51,12 @@ FileSource.prototype.read = function (callback) {
 
 /**
  * Returns which licenses this file potentially declares
- * 
+ *
  * @return {Array} Array of license name strings
  */
-FileSource.prototype.names = function () {
+FileSource.prototype.names = function (options) {
 
-	return licenseFind(this.text);
+	return licenseFind(this.text, options);
 
 };
 

--- a/lib/license-collection.js
+++ b/lib/license-collection.js
@@ -7,7 +7,7 @@
  * @license  The MIT License
  *
  * @@NLF-IGNORE@@
- * 
+ *
  */
 
 'use strict';
@@ -23,10 +23,10 @@ function LicenseCollection() {
 
 /**
  * Returns a summary of licenses
- * 
+ *
  * @return {Array} Array of license names, deduplicated and orered
  */
-LicenseCollection.prototype.summary = function () {
+LicenseCollection.prototype.summary = function (options) {
 
 	var dedup = {},
 		output = [],
@@ -36,7 +36,7 @@ LicenseCollection.prototype.summary = function () {
 		sourceIndex;
 
 	for (sourceIndex = 0; sourceIndex < this.sources.length; sourceIndex++) {
-		names = this.sources[sourceIndex].names();
+		names = this.sources[sourceIndex].names(options);
 		for (nameIndex = 0; nameIndex < names.length; nameIndex++) {
 			name = names[nameIndex];
 			if (!dedup.hasOwnProperty(name)) {
@@ -56,8 +56,8 @@ LicenseCollection.prototype.summary = function () {
 };
 
 /**
- * Add a source to the collection 
- * 
+ * Add a source to the collection
+ *
  * @param  {Object} source The source to add
  */
 LicenseCollection.prototype.add = function (source) {

--- a/lib/license-find.js
+++ b/lib/license-find.js
@@ -8,10 +8,29 @@
  * @license The MIT License
  *
  * @@NLF-IGNORE@@
- * 
+ *
  */
 
 'use strict';
+
+var editDistanceMatch = require('./edit-distance-match'),
+	spdxLicenses = require('spdx-license-list/spdx-full');
+
+// Popular OSI-approved licenses.
+var defaultLicenses = [
+	'Apache-2.0',
+	'BSD-2-Clause',
+	'BSD-3-Clause',
+	'GPL-2.0',
+	'GPL-3.0',
+	'LGPL-2.1',
+	'LGPL-3.0',
+	'MIT',
+	'MPL-2.0',
+	'CDDL-1.0',
+	'EPL-1.0',
+	'ISC'
+];
 
 var patterns = [ {
 		'name': 'BSD',
@@ -79,17 +98,18 @@ var patterns = [ {
 
 /**
  * Identifies potential license text
- * 
+ *
  * @param  {String} text The text to scan
  * @return {Array}       Array of potential license names
  */
-function identifyLicense(text) {
+function identifyLicense(text, options) {
+  /* jshint -W074 */
 
 	var licenseIndex,
 		regexIndex,
 		pattern,
 		output = [];
-		
+
 	// ignore files that have the ignore flag - e.g. the nfl project itself
 	if (!excludePattern.test(text)) {
 		for (licenseIndex = patterns.length - 1; licenseIndex >= 0; licenseIndex--) {
@@ -102,6 +122,17 @@ function identifyLicense(text) {
 			}
 		}
 	}
+
+	if (options) {
+		if (options.editDistance) {
+			if (typeof options.editDistance === 'boolean') {
+				output.push(editDistanceMatch(text, defaultLicenses, spdxLicenses));
+			} else if (options.editDistance instanceof Array) {
+				output.push(editDistanceMatch(text, options.editDistance, spdxLicenses));
+			}
+		}
+	}
+
 
 	return output.sort();
 }

--- a/lib/module.js
+++ b/lib/module.js
@@ -7,7 +7,7 @@
  * @copyright Copyright (C) Ian Kelly 2013
  *
  * @license http://opensource.org/licenses/MIT The MIT License
- * 
+ *
  */
 
 'use strict';
@@ -16,14 +16,14 @@ var LicenseCollection = require('./license-collection');
 
 /**
  * Constructor for Module object - represents one module in the dependency chain
- * 
+ *
  * @param {String} name       The name of the module
  * @param {String} directory  The directory of the module
  * @param {String} repository The repository of the module
- * @param {String} type       The type of the module 
+ * @param {String} type       The type of the module
  *                            (e.g. production, development)
  */
-function Module(id, name, version, directory, repository, type) {
+function Module(id, name, version, directory, repository, type, options) {
 
 	if (!id) {
 		throw new Error('id must be defined');
@@ -41,6 +41,7 @@ function Module(id, name, version, directory, repository, type) {
 		.replace('.git', '');
 	this.directory = directory;
 	this.type = type || '(none)';
+	this.options = options || {};
 
 	this.licenseSources = {
 		'package': new LicenseCollection(),
@@ -51,7 +52,7 @@ function Module(id, name, version, directory, repository, type) {
 
 /**
  * Return a de-duplicated list of all licenses
- * 
+ *
  * @return {Array} An array of license strings
  */
 Module.prototype.summary = function () {
@@ -66,7 +67,8 @@ Module.prototype.summary = function () {
 	// concatenate all the different license source collections
 	for (licenseSourceName in this.licenseSources) {
 		if (this.licenseSources.hasOwnProperty(licenseSourceName)) {
-			all = all.concat(this.licenseSources[licenseSourceName].summary());
+			all = all.concat(
+        this.licenseSources[licenseSourceName].summary(this.options));
 		}
 	}
 

--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -89,7 +89,7 @@ function parseInstalled(data, options, callback) {
 
 			// we're going to call the async function - so increase count
 			count++;
-			createModule(moduleData, function (err, module) {
+			createModule(moduleData, options, function (err, module) {
 				// decrease count when it returns
 				count--;
 
@@ -226,12 +226,12 @@ function addFiles(filePaths, collection, callback) {
  * @param  {Object}   moduleData The module data object
  * @param  {Function} callback   Callback (err, Array of module object)
  */
-function createModule(moduleData, callback) {
+function createModule(moduleData, options, callback) {
 
 	var repository = (moduleData.repository || {}).url || '(none)',
 		directory = moduleData.path,
 		module = new Module(moduleData._id, moduleData.name,
-			moduleData.version, directory, repository);
+			moduleData.version, directory, repository, options);
 
 	// glob for license files
 	findPotentialLicenseFiles(directory, '**/*license*',
@@ -311,6 +311,7 @@ function convertToArray(object) {
  * @return {Object}         Options that have been massaged
  */
 function processOptions(options) {
+  /* jshint -W074 */
 
 	options = options || {};
 
@@ -321,6 +322,7 @@ function processOptions(options) {
 	options.directory = options.directory || process.cwd();
 	options.production = options.production || false;
 	options.depth = typeof options.depth === 'number' ? options.depth : Infinity;
+  options.editDistance = options.editDistance || false;
 
 	if (typeof options.directory !== 'string') {
 		throw new Error('options.directory must be a string');
@@ -328,6 +330,13 @@ function processOptions(options) {
 
 	if (typeof options.production !== 'boolean') {
 		throw new Error('options.production must be a boolean');
+	}
+
+	if (!(typeof options.editDistance === 'boolean' ||
+				(options.editDistance instanceof Array &&
+				 options.editDistance.length > 0))) {
+		throw new Error(
+      'options.editDistance must be a boolean or a non-empty array');
 	}
 
 	return options;

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "archy": "^1.0.0",
     "commander": "^2.5.0",
+    "fast-levenshtein": "^1.0.6",
     "glob": "^4.0.6",
-    "read-installed": "^3.0.0"
+    "read-installed": "^3.0.0",
+    "spdx-license-list": "^1.1.0"
   },
   "devDependencies": {
     "globs": "^0.1.2",

--- a/test/unit/license-find.js
+++ b/test/unit/license-find.js
@@ -12,6 +12,7 @@ require('should');
 
 describe('license-find', function () {
 	/* jshint maxstatements:20 */
+  /* jshint -W101 */
 
 	it('should be a function', function () {
 		licenseFind.should.be.a.function;
@@ -241,6 +242,101 @@ describe('license-find', function () {
 			output[0].should.be.equal('GPL');
 			output[1].should.be.equal('MIT');
 		});
+	});
 
+
+	describe('when given license text not containing a license title', function () {
+		describe('when text corresponds to a popular license', function () {
+			var bsdLicenseText =
+					'Copyright (c) 2015, Joe Schmoe\nAll rights reserved.\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:\n\n1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.\n\n2) Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.\n\nTHIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.';
+
+
+			describe('when options is null', function () {
+				it('should not recognize the license', function () {
+					var output = licenseFind(bsdLicenseText);
+					output.should.be.empty;
+				});
+			});
+
+			describe('when options.editDistance is false', function () {
+				it('should not recognize the license', function () {
+					var output = licenseFind(bsdLicenseText, {editDistance: false});
+					output.should.be.empty;
+				});
+			});
+
+			describe('when options.editDistance is true', function () {
+				it('should recognize the license', function () {
+					var output = licenseFind(bsdLicenseText, {editDistance: true});
+					output.should.eql(['BSD-2-Clause']);
+				});
+			});
+
+			describe('when options.editDistance is an empty array', function () {
+				it('should throw an error', function () {
+					(function () {
+						licenseFind(bsdLicenseText, {editDistance: []});
+					}).should.throwError();
+				});
+			});
+		});
+
+		describe('when text corresponds to an obscure license', function () {
+			var zedLicenseText =
+					'(c) Jim Davies, January 1995\nYou may copy and distribute this file freely.	Any queries and complaints should be forwarded to Jim.Davies@comlab.ox.ac.uk.\nIf you make any changes to this file, please do not distribute the results under the name `zed-csp.sty\'.';
+
+
+			describe('when options is null', function () {
+				it('should not recognize the license', function () {
+					var output = licenseFind(zedLicenseText);
+					output.should.be.empty;
+				});
+			});
+
+			describe('when options.editDistance is false', function () {
+				it('should not recognize the license', function () {
+					var output = licenseFind(zedLicenseText, {editDistance: false});
+					output.should.be.empty;
+				});
+			});
+
+			describe('when options.editDistance is true', function () {
+				it('should recognize a different license', function () {
+					var output = licenseFind(zedLicenseText, {editDistance: true});
+					output.should.not.equal('Zed');
+				});
+			});
+
+			describe('when options.editDistance is an empty array', function () {
+				it('should throw an error', function () {
+					(function () {
+						licenseFind(zedLicenseText, {editDistance: []});
+					}).should.throwError();
+				});
+			});
+
+			describe('when options.editDistance is an array containing a popular SPDX license key', function () {
+				it('should recognize a different license', function () {
+					var output = licenseFind(zedLicenseText, {editDistance: ['BSD-2-Clause']});
+					output.should.not.equal('Zed');
+				});
+			});
+
+			describe('when options.editDistance is an array containing a non-SPDX license key', function () {
+				it('should throw an error', function () {
+					(function () {
+						licenseFind(zedLicenseText, {editDistance: ['Bogus-Key']});
+					}).should.throwError();
+				});
+			});
+
+			describe('when options.editDistance is an array containing the SPDX key of the obscure license', function () {
+				it('should recognize the the license', function () {
+					var output = licenseFind(zedLicenseText, {editDistance: ['YPL-1.1', 'Zed', 'BSD-2-Clause']});
+					output.should.eql(['Zed']);
+				});
+			});
+
+		});
 	});
 });

--- a/test/unit/module.js
+++ b/test/unit/module.js
@@ -54,6 +54,19 @@ describe('Module', function () {
 			myModule.type.should.be.equal('development');
 		});
 
+		describe('when given options', function () {
+			it('should set the options', function () {
+				var myModule = new Module('my-module@1.0.0',
+					'my-module',
+					'1.0.0',
+					'/my/dir',
+					'https://myhost/myrepo',
+					'development',
+					{editDistance: true});
+				myModule.options.should.eql({editDistance: true});
+			});
+		});
+
 		it('with no name should throw an exception', function () {
 			(function () {
 				new Module(undefined, undefined, undefined, '/my/dir');

--- a/test/unit/nlf.js
+++ b/test/unit/nlf.js
@@ -126,7 +126,7 @@ describe('nlf', function () {
 				},
 				function (err, results) {
 					/*jshint unused:false */
-					results.length.should.eql(5);
+					results.length.should.eql(7);
 					done();
 				});
 
@@ -144,7 +144,7 @@ describe('nlf', function () {
 				},
 				function (err, results) {
 					/*jshint unused:false */
-					results.length.should.eql(8);
+					results.length.should.eql(10);
 					done();
 				});
 
@@ -162,7 +162,7 @@ describe('nlf', function () {
 				},
 				function (err, results) {
 					/*jshint unused:false */
-					results.length.should.eql(23);
+					results.length.should.eql(28);
 					done();
 				});
 


### PR DESCRIPTION
@iandotkelly Wondering if you'd be interested in accepting this. This adds the ability to optionally use the Levenshtein edit distance to deduce licenses in LICENSE files.