### PR TITLE
Support (deprecated) license object syntax

### DIFF
--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -267,7 +267,7 @@ function addPackageJson(moduleData, module) {
 
 	// finally, if there is data in package.json relating to licenses
 	// simple license declarations first
-	if (typeof license === 'string') {
+	if (typeof license === 'string' || typeof license === 'object') {
 		module.licenseSources.package.add(new PackageSource(license));
 	}
 

--- a/test/fixtures/license-object/package.json
+++ b/test/fixtures/license-object/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module",
+  "title": "NLF Test Project",
+  "description": "Test project for unit tests",
+  "author": "Ian Kelly <iandotkelly@gmail.com>",
+  "version": "1.0.0",
+  "license": {
+    "type": "MIT",
+    "url": "http://opensource.org/licenses/MIT"
+  }
+}

--- a/test/unit/nlf.js
+++ b/test/unit/nlf.js
@@ -9,6 +9,7 @@ var path = require('path');
 
 var fixturedir = path.join(__dirname, '../fixtures/test-project');
 var licensesArrayDir = path.join(__dirname, '../fixtures/licenses-array');
+var licenseObjectDir = path.join(__dirname, '../fixtures/license-object');
 var licensesStringDir = path.join(__dirname, '../fixtures/licenses-string');
 var missingName = path.join(__dirname, '../fixtures/missing-name');
 
@@ -196,6 +197,28 @@ describe('nlf', function () {
 					done();
 				});
 
+		});
+
+		describe('with a license object', function () {
+
+			it('should correctly get the license', function(done) {
+
+				nlf.find(
+					{
+						directory: licenseObjectDir
+					},
+					function (err, results) {
+						if (err) {
+							throw err;
+						}
+						results.length.should.eql(1);
+						var sources = results[0].licenseSources.package.sources;
+						sources.length.should.eql(1);
+						sources[0].license.should.eql('MIT');
+						done();
+					});
+
+			});
 		});
 
 		describe('with an array of licenses', function () {


### PR DESCRIPTION
As stated at https://docs.npmjs.com/files/package.json#license.
Because there are a lot of packages still using it.