### PR TITLE
Update log function to match read-installed's callback signature

### DIFF
--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -452,10 +452,10 @@ function find(options, callback) {
 	 * Function called when readInstalled hits an issue
 	 *
 	 * @param  {String} output The error message
+	 * @param  {String} details The error details
 	 */
-	function log(output) {
-		console.error('Error in reading node_module dependencies, error was: '
-			+ output);
+	function log(output, details) {
+		console.error('Error in reading node_module dependencies, error was:', output, details);
 	}
 
 	if (!fileExistsSync(path.join(options.directory, 'package.json'))) {

--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -455,7 +455,8 @@ function find(options, callback) {
 	 * @param  {String} details The error details
 	 */
 	function log(output, details) {
-		console.error('Error in reading node_module dependencies, error was:', output, details);
+		console.error('Error in reading node_module dependencies, error was:',
+            output, details);
 	}
 
 	if (!fileExistsSync(path.join(options.directory, 'package.json'))) {


### PR DESCRIPTION
The relevant details of the only error message read-installed actually sends via this function are in the second argument:

https://github.com/npm/read-installed/blob/master/read-installed.js#L311-L314