### PR TITLE
Fix: dev dependencies are shown in --no-dev mode.

### DIFF
--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -35,6 +35,10 @@ function isDevDependency(moduleData) {
 		return false;
 	}
 
+	if (moduleData.extraneous) {
+		return true;
+	}
+
 	var dependencies = moduleData.parent.devDependencies || {},
 		dependencyName;
 


### PR DESCRIPTION
Fix iandotkelly/nlf#31 

Bypass extraneous modules in --no-dev mode.