### PR TITLE
Show modules group by licenses

### DIFF
--- a/bin/nlf-cli.js
+++ b/bin/nlf-cli.js
@@ -24,12 +24,14 @@ var program = require('commander'),
 program
 	.version(pjson.version)
 	.option('-d, --no-dev', 'exclude development dependencies')
+	.option('-s, --summary <mode>', 'summary (not available in csv format): off | simple (default) | detail', /^(off|simple|detail)$/i, 'simple')
 	.option('-c, --csv', 'output in csv format')
 	.option('-r, --reach [num]', 'package depth (reach)', parseInt, Infinity)
 	.parse(process.argv);
 
 options.production = !program.dev;
 options.depth = program.reach;
+options.summaryMode = program.summary;
 
 // select which formatter
 if (program.csv) {
@@ -46,7 +48,7 @@ nlf.find(options, function (err, data) {
 	}
 
 	if (data && data.length > 0) {
-		format.render(data, function (err, output) {
+		format.render(data, options, function (err, output) {
 			if (err) {
 				console.error(err);
 				process.exit(1);

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -36,9 +36,10 @@ function recordToCsv(moduleRecord) {
  * Render the license data
  * 
  * @param  {Array}    licenseData An array of module licence data
+ * @param  {Object}   options     Options
  * @param  {Function} callback    The callback (err, output string)
  */
-function render(licenseData, callback) {
+function render(licenseData, options, callback) {
 
 	if (typeof callback !== 'function') {
 		throw new Error('must have a callback');

--- a/lib/formatters/standard.js
+++ b/lib/formatters/standard.js
@@ -45,13 +45,6 @@ function createModuleNode(moduleData) {
 	return archy(output);
 }
 
-function createLicenseNode(license, modules) {
-	return {
-		label: license,
-		nodes: modules 
-	};
-}
-
 /**
  * Create an archy formatted summary of the licenses found
  *

--- a/lib/formatters/standard.js
+++ b/lib/formatters/standard.js
@@ -45,23 +45,54 @@ function createModuleNode(moduleData) {
 	return archy(output);
 }
 
+function createLicenseNode(license, modules) {
+	return {
+		label: license,
+		nodes: modules 
+	};
+}
+
 /**
  * Create an archy formatted summary of the licenses found
  *
- * @param {Array} summaryData Array of licenses found
+ * @param {Object} summaryData Map: license -> modules
  */
-function createSummary(summaryData) {
+function createSummary(summmaryData) {
 	return archy({
-		label: 'LICENSES: ' + summaryData.sort().join(', ')
+		label: 'LICENSES: ' + Object.keys(summmaryData).sort().join(', ')
 	});
 }
+
+
+/**
+ * Create an archy output of the modules group by license
+ * 
+ * @param {Object} summaryData Map: license -> modules
+ */
+function modulesByLicenses(summaryData) {
+	var output = {
+		label: 'LICENSES:',
+		nodes: []
+	};
+	for (var license in summaryData) {
+		if (summaryData.hasOwnProperty(license)) {
+			output.nodes.push({
+				label: license,
+				nodes: summaryData[license]
+			});
+		}
+	}
+	return archy(output);
+}
+
 /**
  * Render the license data
  *
  * @param  {Array}    licenseData An array of module licence data
+ * @param  {Object}   options     Options
  * @param  {Function} callback    The callback (err, output string)
  */
-function render(licenseData, callback) {
+function render(licenseData, options, callback) {
 
 	if (typeof callback !== 'function') {
 		throw new Error('must have a callback');
@@ -76,7 +107,7 @@ function render(licenseData, callback) {
 	}
 
 	var output = [];
-	var summary = [];
+	var summary = {};
 
 	// go through all the modules, adding them to
 	// the output archy formatted data
@@ -85,14 +116,23 @@ function render(licenseData, callback) {
 		// add new licenses to the summary
 		var moduleLicenses = module.summary();
 		for (var index = 0; index < moduleLicenses.length; index++) {
-			if (summary.indexOf(moduleLicenses[index]) === -1) {
-				summary.push(moduleLicenses[index]);
+			var license = moduleLicenses[index];
+			if (!summary[license]) {
+				summary[license] = [];
 			}
+			summary[license].push(module.id);
 		}
 	});
 
 	// add the summary
-	output.push(createSummary(summary));
+	switch (options.summaryMode) {
+		case 'simple': 
+			output.push(createSummary(summary));
+			break;
+		case 'detail':
+			output.push(modulesByLicenses(summary));
+			break;
+	}
 
 	callback(null, output.join('\n'));
 }

--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -405,6 +405,12 @@ function processOptions(options) {
 		throw new Error('options.production must be a boolean');
 	}
 
+	options.summaryMode = options.summaryMode || 'simple';
+	if (typeof options.summaryMode !== 'string') {
+		throw new Error('options.summaryMode must be a string');
+	}
+	options.summaryMode = options.summaryMode.toLowerCase();
+	
 	return options;
 }
 

--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -379,6 +379,14 @@ function convertToArray(object) {
 	return output;
 }
 
+function processOptionSummaryMode(options) {
+	options.summaryMode = options.summaryMode || 'simple';
+	if (typeof options.summaryMode !== 'string') {
+		throw new Error('options.summaryMode must be a string');
+	}
+	options.summaryMode = options.summaryMode.toLowerCase();
+}
+
 /**
  * Process the options
  *
@@ -404,13 +412,9 @@ function processOptions(options) {
 	if (typeof options.production !== 'boolean') {
 		throw new Error('options.production must be a boolean');
 	}
-
-	options.summaryMode = options.summaryMode || 'simple';
-	if (typeof options.summaryMode !== 'string') {
-		throw new Error('options.summaryMode must be a string');
-	}
-	options.summaryMode = options.summaryMode.toLowerCase();
 	
+	processOptionSummaryMode(options);
+
 	return options;
 }
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ nlf can be used programmatically, or from the command line.
 - `directory` (String) - where to look
 - `production` (Boolean) (Default:false) - only traverse dependencies, no dev-dependencies
 - `depth` (Number) (Default: Infinity) - how deep to traverse packages where 0 is the current package.json only
+- `summaryMode` (String: off|simple|detail) (Default: simple)
 
 
 ### CLI

--- a/test/unit/formatters/csv.js
+++ b/test/unit/formatters/csv.js
@@ -55,7 +55,7 @@ describe('csv formatter', function () {
 
 			it('should return an error', function () {
 
-				csvFormat.render(undefined, function (err) {
+				csvFormat.render(undefined, {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -69,19 +69,19 @@ describe('csv formatter', function () {
 
 			it('should return an error', function () {
 
-				csvFormat.render(1, function (err) {
+				csvFormat.render(1, {}, function (err) {
 
 					err.should.be.an.object;
 
 				});
 
-				csvFormat.render(true, function (err) {
+				csvFormat.render(true, {}, function (err) {
 
 					err.should.be.an.object;
 
 				});
 
-				csvFormat.render('cats', function (err) {
+				csvFormat.render('cats', {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -95,7 +95,7 @@ describe('csv formatter', function () {
 
 			it('should return an error', function () {
 
-				csvFormat.render([], function (err) {
+				csvFormat.render([], {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -113,7 +113,7 @@ describe('csv formatter', function () {
 						throw err;
 					}
 
-					csvFormat.render(input, function (err, output) {
+					csvFormat.render(input, {}, function (err, output) {
 
 						if (err)
 						{

--- a/test/unit/formatters/standard.js
+++ b/test/unit/formatters/standard.js
@@ -14,6 +14,7 @@ var standardFormat = require('../../..').standardFormatter,
 	input = [],
 	mod,
 	path = require('path'),
+	expectedWithDatailSummary,
 	expected;
 
 require('should');
@@ -33,6 +34,16 @@ expected = 'test@1.0.0 [license(s): Apache, MIT]\n'
 	+ '├── license files: MIT\n'
 	+ '└── readme files: MIT\n\n'
 	+ 'LICENSES: Apache, MIT\n';
+
+expectedWithDatailSummary = 'test@1.0.0 [license(s): Apache, MIT]\n'
+	+ '├── package.json:  Apache\n'
+	+ '├── license files: MIT\n'
+	+ '└── readme files: MIT\n\n'
+	+ 'LICENSES:\n'
+	+ '├─┬ Apache\n'
+	+ '│ └── test@1.0.0\n'
+	+ '└─┬ MIT\n'
+	+ '  └── test@1.0.0\n';
 
 describe('standard formatter', function () {
 
@@ -66,7 +77,7 @@ describe('standard formatter', function () {
 
 			it('should return an error', function () {
 
-				standardFormat.render(undefined, function (err) {
+				standardFormat.render(undefined, {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -80,19 +91,19 @@ describe('standard formatter', function () {
 
 			it('should return an error', function () {
 
-				standardFormat.render(1, function (err) {
+				standardFormat.render(1, {}, function (err) {
 
 					err.should.be.an.object;
 
 				});
 
-				standardFormat.render(true, function (err) {
+				standardFormat.render(true, {}, function (err) {
 
 					err.should.be.an.object;
 
 				});
 
-				standardFormat.render('cats', function (err) {
+				standardFormat.render('cats', {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -106,7 +117,7 @@ describe('standard formatter', function () {
 
 			it('should return an error', function () {
 
-				standardFormat.render([], function (err) {
+				standardFormat.render([], {}, function (err) {
 
 					err.should.be.an.object;
 
@@ -127,7 +138,8 @@ describe('standard formatter', function () {
 					if (err) {
 						throw err;
 					}
-					standardFormat.render(input, function (err, output) {
+					standardFormat.render(input, {summaryMode: 'simple'}, 
+					  function (err, output) {
 
 						if (err)
 						{
@@ -140,5 +152,32 @@ describe('standard formatter', function () {
 				});
 			});
 		});
+
+		it('should return detail summary', function (done) {
+
+			mod.licenseSources.license.sources[0].read(function (err) {
+				if (err) {
+					throw err;
+				}
+
+				mod.licenseSources.readme.sources[0].read(function (err) {
+					if (err) {
+						throw err;
+					}
+					standardFormat.render(input, {summaryMode: 'detail'}, 
+					  function (err, output) {
+
+						if (err)
+						{
+							throw err;
+						}
+
+						output.should.be.equal(expectedWithDatailSummary);
+						done();
+					});
+				});
+			});
+		});
+
 	});
 });


### PR DESCRIPTION
Add `--summary <mode>` option, which can be set to "off", "simple" or "detail". This option controls what will be printed in summary in standard format.

* `off` turns off summary output
* `simple` shows a list of licenses used in the project. It's what nlf used to output. To keep compatibility, "simple" is the default mode if the summary option isn't given.
* `detail` shows all modules in current project and group by licenses. As example below.

```
LICENSES:
├─┬ BSD
│ ├── amdefine@1.0.0
│ ├── boom@0.4.2
│ ├── cryptiles@0.2.2
│ └── diff@1.4.0
├─┬ BSD-2-Clause
│ └── normalize-package-data@2.3.5
├─┬ Apache-2.0
│ ├── request@2.40.0
│ ├── spdx-correct@1.0.2
│ └── validate-npm-package-license@3.0.1
├─┬ (MIT AND CC-BY-3.0)
│ └── spdx-expression-parse@1.0.1
└─┬ MPL
  └── tough-cookie@2.2.1
```


