### PR TITLE
Matches license when at end of line

### DIFF
--- a/lib/license-find.js
+++ b/lib/license-find.js
@@ -8,7 +8,7 @@
  * @license The MIT License
  *
  * @@NLF-IGNORE@@
- * 
+ *
  */
 
 'use strict';
@@ -16,59 +16,59 @@
 var patterns = [ {
 		'name': 'BSD',
 		'regex': [
-			/(?:^|\s)BSD\s/
+			/(?:^|\s)BSD(?:$|\s)/
 		]
 	},
 	{
 		'name': 'GPL',
 		'regex': [
-			/(?:^|\s)GPL\s/,
-			/(?:^|\s)GPLv\d\s/
+			/(?:^|\s)GPL(?:$|\s)/,
+			/(?:^|\s)GPLv\d(?:$|\s)/
 		]
 	},
 	{
 		'name': 'LGPL',
 		'regex': [
-			/(?:^|\s)LGPL\s/
+			/(?:^|\s)LGPL(?:$|\s)/
 		]
 	},
 	{
 		'name': 'MIT',
 		'regex' : [
-			/(?:^|\s)MIT\s/,
-			/(?:^|\s)\(MIT\)\s/
+			/(?:^|\s)MIT(?:$|\s)/,
+			/(?:^|\s)\(MIT\)(?:$|\s)/
 		]
 	},
 	{
 		'name': 'Apache',
 		'regex': [
-			/(?:^|\s)Apache\sLicen[cs]e\s/i
+			/(?:^|\s)Apache\sLicen[cs]e(?:$|\s)/i
 		]
 	},
 	{
 		'name': 'MPL',
 		'regex': [
-			/(?:^|\s)MPL\s/
+			/(?:^|\s)MPL(?:$|\s)/
 		]
 	},
 	{
 		'name': 'WTFPL',
 		'regex': [
-			/(?:^|\s)WTFPL\s/,
-			/(?:^|\s)DO\sWHAT\sTHE\sFUCK\sYOU\sWANT\sTO\sPUBLIC\sLICEN[CS]E\s/i
+			/(?:^|\s)WTFPL(?:$|\s)/,
+			/(?:^|\s)DO\sWHAT\sTHE\sFUCK\sYOU\sWANT\sTO\sPUBLIC\sLICEN[CS]E(?:$|\s)/i
 		]
 	},
 	{
 		'name': 'ISC',
 		'regex': [
-			/(?:^|\s)ISC\s/,
-			/(?:^|\s)\(ISC\)\s/
+			/(?:^|\s)ISC(?:$|\s)/,
+			/(?:^|\s)\(ISC\)(?:$|\s)/
 		]
 	},
 	{
 		'name': 'Eclipse Public License',
 		'regex': [
-			/(?:^|\s)Eclipse\sPublic\sLicen[cs]e\s/i,
+			/(?:^|\s)Eclipse\sPublic\sLicen[cs]e(?:$|\s)/i,
 			/(?:^|\s)EPL\s/,
 			/(?:(?:^|\s)|\()EPL-1\.0(?:\)|\s)/
 		]
@@ -79,17 +79,16 @@ var patterns = [ {
 
 /**
  * Identifies potential license text
- * 
+ *
  * @param  {String} text The text to scan
  * @return {Array}       Array of potential license names
  */
 function identifyLicense(text) {
-
 	var licenseIndex,
 		regexIndex,
 		pattern,
 		output = [];
-		
+
 	// ignore files that have the ignore flag - e.g. the nfl project itself
 	if (!excludePattern.test(text)) {
 		for (licenseIndex = patterns.length - 1; licenseIndex >= 0; licenseIndex--) {


### PR DESCRIPTION
When the readme file is : 

```
MIT
```

(without a trailing new line at the end of the file), the detection of the license fails.

This happens on for example : https://www.npmjs.com/package/object-component, which is a pretty popular package

This fixes this