### PR TITLE
allow license file variations

### DIFF
--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -318,7 +318,7 @@ function createModule(moduleData, callback) {
 	var module = new Module(id, name, version, directory, repository);
 
 	// glob for license files
-	findPotentialLicenseFiles(directory, '*license*',
+	findPotentialLicenseFiles(directory, '*li@(c|s)en@(c|s)e*',
 		function (err, licenseFiles) {
 
 		if (err) {


### PR DESCRIPTION
Sometimes license files are named "LICENCE" or have c & s spelling mistakes.
This allows all four variations: LICENSE, LICENCE, LISENSE, LISENCE