### PR TITLE
Handle when package.json declares repository as a string

### DIFF
--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -281,7 +281,8 @@ function addPackageJson(moduleData, module) {
  */
 function createModule(moduleData, callback) {
 
-	var repository = (moduleData.repository || {}).url || moduleData.repository || '(none)';
+	var repository = (moduleData.repository || {}).url || 
+	    moduleData.repository || '(none)';
 	var directory = path.dirname(moduleData.__filename);
 	var id = moduleData.full;
 	var name = moduleData.name || id;

--- a/lib/nlf.js
+++ b/lib/nlf.js
@@ -281,7 +281,7 @@ function addPackageJson(moduleData, module) {
  */
 function createModule(moduleData, callback) {
 
-	var repository = (moduleData.repository || {}).url || '(none)';
+	var repository = (moduleData.repository || {}).url || moduleData.repository || '(none)';
 	var directory = path.dirname(moduleData.__filename);
 	var id = moduleData.full;
 	var name = moduleData.name || id;


### PR DESCRIPTION
Sometimes module owners use `repository: ""` instead of `repository: { url: ""}` .

This would handle that case in the module scanning process