### PR TITLE
Resolve issue where github URLs are reported as http://wwwhub.com

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,7 @@ function Module(id, name, version, directory, repository, type) {
 	this.version = version;
 	this.repository = (repository || '(none)')
 		.replace('git://', 'http://')
-		.replace('.git', '')
+		.replace(/\.git$/, '')
 		.replace(/^git\+/, '');
 	this.directory = directory;
 	this.type = type || '(none)';

--- a/test/unit/module.js
+++ b/test/unit/module.js
@@ -75,6 +75,17 @@ describe('Module', function () {
 			myModule.repository.should.be.equal('http://myhost/myrepo');
 		});
 
+		it('should remove .git postfix only from repository URL',
+			function () {
+			var myModule = new Module(
+				'my-module@1.0.0',
+				undefined,
+				undefined,
+				'/my/dir',
+				'http://www.github.com/myrepo.git');
+			myModule.repository.should.be.equal('http://www.github.com/myrepo');
+		});
+
 		it('with no name should throw an exception', function () {
 			(function () {
 				new Module(undefined, undefined, undefined, '/my/dir');


### PR DESCRIPTION
For projects that use `"url": "https://github.com/DefinitelyTyped/DefinitelyTyped.git"` the old regex worked fine, but some are now using `"url": "https://www.github.com/DefinitelyTyped/DefinitelyTyped.git"` which comes back as `wwwhub`.

Simple regex fix and I also added a test.