### PR TITLE
Allow repository as object

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -7,7 +7,7 @@
  * @copyright Copyright (C) Ian Kelly 2013
  *
  * @license http://opensource.org/licenses/MIT The MIT License
- * 
+ *
  */
 
 'use strict';
@@ -16,11 +16,11 @@ var LicenseCollection = require('./license-collection');
 
 /**
  * Constructor for Module object - represents one module in the dependency chain
- * 
+ *
  * @param {String} name       The name of the module
  * @param {String} directory  The directory of the module
  * @param {String} repository The repository of the module
- * @param {String} type       The type of the module 
+ * @param {String} type       The type of the module
  *                            (e.g. production, development)
  */
 function Module(id, name, version, directory, repository, type) {
@@ -36,6 +36,9 @@ function Module(id, name, version, directory, repository, type) {
 	this.id = id;
 	this.name = name;
 	this.version = version;
+	if (typeof repository === 'object') {
+		repository = repository.url;
+	}
 	this.repository = (repository || '(none)')
 		.replace('git://', 'http://')
 		.replace(/\.git$/, '')
@@ -52,7 +55,7 @@ function Module(id, name, version, directory, repository, type) {
 
 /**
  * Return a de-duplicated list of all licenses
- * 
+ *
  * @return {Array} An array of license strings
  */
 Module.prototype.summary = function () {

--- a/test/unit/module.js
+++ b/test/unit/module.js
@@ -86,6 +86,17 @@ describe('Module', function () {
 			myModule.repository.should.be.equal('http://www.github.com/myrepo');
 		});
 
+		it('should handle object as repository',
+			function () {
+			var myModule = new Module(
+				'my-module@1.0.0',
+				undefined,
+				undefined,
+				'/my/dir',
+				{type: 'git', url: 'git+https://myhost/myrepo.git'});
+			myModule.repository.should.be.equal('https://myhost/myrepo');
+		});
+
 		it('with no name should throw an exception', function () {
 			(function () {
 				new Module(undefined, undefined, undefined, '/my/dir');


### PR DESCRIPTION
The package.json repository attribute can be provided as object of
the form `{type: 'git': url: 'https://github.com/npm/cli.git'}`
https://docs.npmjs.com/files/package.json